### PR TITLE
added kind = "bar" option in shap.plot.summary

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: SHAPforxgboost
 Title: SHAP Plots for 'XGBoost'
-Version: 0.1.1
-Date: 2021-03-23
+Version: 0.1.2
+Date: 2022-05-17
 Authors@R: c(
     person(given = "Yang", family = "Liu", role = c("aut", "cre"), email = "lyhello@gmail.com",
            comment = c(ORCID = "0000-0001-6557-6439")),
@@ -41,4 +41,4 @@ Suggests:
     parallel,
     lightgbm (>= 2.1)
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# SHAPforxgboost 0.1.2
+
+* 17/05/2022 Added option `kind = "bar"` to `shap.plot.summary()`.
+
 # SHAPforxgboost 0.1.1
 
 * 22/03/2021 Moved `lightgbm` from imported to suggested package.

--- a/R/SHAP_funcs.R
+++ b/R/SHAP_funcs.R
@@ -215,6 +215,10 @@ shap.prep.interaction <- function(xgb_model, X_train){
 #'   scaled between min_color_bound and max_color_bound. Default is "#FFCC33".
 #' @param max_color_bound max color hex code for colormap. Color gradient is
 #'   scaled between min_color_bound and max_color_bound. Default is "#6600CC".
+#' @param kind By default, a "sina" plot is shown. As an alternative,
+#'   set \code{kind = "bar"} to visualize mean absolute SHAP values as a
+#'   barplot. Its color is controlled by \code{max_color_bound}. Other
+#'   arguments are ignored for this kind of plot.
 #'
 #' @import ggplot2
 #' @importFrom ggforce geom_sina
@@ -229,7 +233,21 @@ shap.plot.summary <- function(data_long,
                               scientific = FALSE,
                               my_format = NULL,
                               min_color_bound = "#FFCC33",
-                              max_color_bound = "#6600CC"){
+                              max_color_bound = "#6600CC",
+                              kind = c("sina", "bar")){
+
+  kind <- match.arg(kind)
+  if (kind == "bar") {
+    imp <- shap.importance(data_long)
+    p <- ggplot(imp, aes(x = variable, y = mean_abs_shap)) +
+      geom_bar(stat = "identity", fill = max_color_bound) +
+      coord_flip() +
+      scale_x_discrete(limits = rev(levels(imp[["variable"]]))) +
+      theme_bw() +
+      theme(axis.title.x = element_text(size = 10)) +
+      labs(x = element_blank(), y = "Avg(|SHAP|)")
+    return(p)
+  }
 
   if (scientific){label_format = "%.1e"} else {label_format = "%.3f"}
   if (!is.null(my_format)) label_format <- my_format

--- a/man/shap.plot.summary.Rd
+++ b/man/shap.plot.summary.Rd
@@ -11,7 +11,8 @@ shap.plot.summary(
   scientific = FALSE,
   my_format = NULL,
   min_color_bound = "#FFCC33",
-  max_color_bound = "#6600CC"
+  max_color_bound = "#6600CC",
+  kind = c("sina", "bar")
 )
 }
 \arguments{
@@ -37,6 +38,11 @@ scaled between min_color_bound and max_color_bound. Default is "#FFCC33".}
 
 \item{max_color_bound}{max color hex code for colormap. Color gradient is
 scaled between min_color_bound and max_color_bound. Default is "#6600CC".}
+
+\item{kind}{By default, a "sina" plot is shown. As an alternative,
+set \code{kind = "bar"} to visualize mean absolute SHAP values as a
+barplot. Its color is controlled by \code{max_color_bound}. Other
+arguments are ignored for this kind of plot.}
 }
 \value{
 returns a ggplot2 object, could add further layers.

--- a/vignettes/basic_workflow.Rmd
+++ b/vignettes/basic_workflow.Rmd
@@ -66,6 +66,9 @@ shap <- shap.prep(fit, X_train = X)
 # SHAP importance plot
 shap.plot.summary(shap)
 
+# Alternatively, mean absolute SHAP values
+shap.plot.summary(shap, kind = "bar")
+
 # Dependence plots in decreasing order of importance
 # (colored by strongest interacting variable)
 for (x in shap.importance(shap, names_only = TRUE)) {


### PR DESCRIPTION
I added a new option to `shap.plot.summary()`, called `kind = "bar"`, to show simple (and fast) bar plots for variable importance. Per default, `kind = "sina"`.

<img width="311" alt="image" src="https://user-images.githubusercontent.com/16206095/168765447-e82bec28-a61b-4463-b61c-309dab13811a.png">

Let me know if we need more flexibility/more options.