### PR TITLE
LightGBM v4

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,6 +25,7 @@ VignetteBuilder:
     knitr
 Imports:
     stats,
+    utils,
     ggplot2 (>= 3.0.0),
     xgboost (>= 0.81.0.0),
     data.table (>= 1.12.0),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # SHAPforxgboost 0.1.2
 
+* 08/06/2022 Comply to LightGBM's 4.0 `predict()` interface. 
 * 17/05/2022 Added option `kind = "bar"` to `shap.plot.summary()`.
 
 # SHAPforxgboost 0.1.1

--- a/R/SHAP_funcs.R
+++ b/R/SHAP_funcs.R
@@ -38,9 +38,12 @@
 shap.values <- function(xgb_model,
                         X_train){
 
-  shap_contrib <- predict(xgb_model,
-                          (X_train),
-                          predcontrib = TRUE)
+  # New predict() interface for LGB 4
+  if (inherits(xgb_model, "lgb.Booster") && utils::packageVersion("lightgbm") >= 4) {
+    shap_contrib <- predict(xgb_model, X_train, type = "contrib")
+  } else {
+    shap_contrib <- predict(xgb_model, X_train, predcontrib = TRUE)
+  }
 
   # Add colnames if not already there (required for LightGBM)
   if (is.null(colnames(shap_contrib))) {

--- a/R/SHAP_funcs.R
+++ b/R/SHAP_funcs.R
@@ -38,8 +38,9 @@
 shap.values <- function(xgb_model,
                         X_train){
 
-  # New predict() interface for LGB 4
-  if (inherits(xgb_model, "lgb.Booster") && utils::packageVersion("lightgbm") >= 4) {
+  # New predict() interface for LGB > 3.3.2
+  new_lgb <- utils::packageVersion("lightgbm") > package_version("3.3.2")
+  if (inherits(xgb_model, "lgb.Booster") && new_lgb) {
     shap_contrib <- predict(xgb_model, X_train, type = "contrib")
   } else {
     shap_contrib <- predict(xgb_model, X_train, predcontrib = TRUE)


### PR DESCRIPTION
There is an open PR changing the predict() interface of LightGBM:
https://github.com/microsoft/LightGBM/pull/5133

We should wait with merging this PR here until the LGB PR is accepted and the upcoming LGB version is clear. 

